### PR TITLE
serviceAccount refactor for env at backend

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,16 +2,15 @@ require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const { connectDB } = require('./config/db.js');
-const { cert } = require('firebase-admin/app'); 
-const admin = require('firebase-admin'); 
+const { cert } = require('firebase-admin/app');
+const admin = require('firebase-admin');
 const userRoutes = require('./routes/user-routes.js');
 const postRoutes = require('./routes/post-routes');
 const triviaRoutes = require('./routes/trivia-routes');
 const insightsRoutes = require('./routes/insights-routes');
 const path = require('path');
 
-const serviceAccount = require('./config/serviceAccountKey.json'); // Load service account JSON
-
+const serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT);
 
 // Define port from environment variables or fallback to 5000
 const PORT = process.env.PORT || 5000;


### PR DESCRIPTION
This pull request includes a change to how the service account key is loaded in the `backend/app.js` file. The most important change is the modification of the `serviceAccount` variable to load the Firebase service account key from an environment variable instead of a JSON file.

* [`backend/app.js`](diffhunk://#diff-57fcf3bf0ff2ec3604e842595d8ac0b6a43665dac4d20b3da0136bd02dc36cd7L13-R13): Changed the `serviceAccount` variable to parse the Firebase service account key from the `FIREBASE_SERVICE_ACCOUNT` environment variable instead of loading it from a JSON file.