### PR TITLE
moved vite from devd to dependicies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,8 @@
     "react": "^18.3.1",
     "react-bootstrap": "^2.10.5",
     "react-dom": "^18.3.1",
+    "vite": "^5.4.1",
+    "@vitejs/plugin-react": "^4.3.1",
     "react-infinite-scroll-component": "^6.1.0",
     "react-router-dom": "^6.26.2",
     "react-select": "^5.8.3"
@@ -28,13 +30,11 @@
     "@eslint/js": "^9.9.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "^4.3.1",
     "eslint": "^9.9.0",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",
-    "prettier": "^3.3.3",
-    "vite": "^5.4.1"
+    "prettier": "^3.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
+    "engines": {
+      "node": "18.x"
+    },
     "scripts": {
-        "start": "cd backend && node app.js",
-        "heroku-postbuild": "cd frontend && npm install && npm run build && mv dist ../backend/"
+      "start": "cd backend && node app.js",
+      "heroku-postbuild": "cd frontend && npm install && npm run build && mv dist ../backend/"
     }
-}
+  }


### PR DESCRIPTION
This pull request includes updates to dependencies and configuration files in the `frontend` and root directories. The most important changes include adding and removing dependencies in `frontend/package.json` and specifying the Node.js version in the root `package.json`.

Dependency updates:

* [`frontend/package.json`](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R23-R24): Added `vite` and `@vitejs/plugin-react` dependencies.
* [`frontend/package.json`](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L31-R38): Removed `vite` and `@vitejs/plugin-react` dependencies from the devDependencies section.

Configuration updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R2-R4): Specified Node.js version 18.x in the `engines` field.